### PR TITLE
A utilty to compose DeepSpeech CSV

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+*/node_modules
+*/package-lock.json

--- a/compose-deepspeech-csv/README.md
+++ b/compose-deepspeech-csv/README.md
@@ -1,0 +1,29 @@
+# DeepSpeech CSV Composer
+An utility tool to generate the CSV for [DeepSpeech](https://github.com/mozilla/DeepSpeech).
+
+### Install the dependencies
+```
+npm install
+```
+
+### Configuration
+The utility reads an CSV as input, which contains the wav filename and transcript and maybe other information in each row. In the `config.json`, you need to specify the column index (starting from 0) for both wav file name and transcript.
+
+The example content of `config.json`
+```JSON
+{
+  "fileName": 9,
+  "transcript": 10
+}
+```
+`fileName` denotes the column index for the file name of wav file.
+The file path could be absolute path or relative path to the `index.js`.
+
+`transcript` denotes the column index for the transcript.
+
+### Usage
+In order to run the utility, you need to put your data set into 3 directories: `train`, `test` and `validate`. And make sure the file name
+in the `fileName` column point to the wav files inside these directories. And use the following command to generate the CSV for DeepSpeech:
+```
+node index.js <your CSV> <parent directory of train, test and validate> <csv output directory>
+``` 

--- a/compose-deepspeech-csv/config.json
+++ b/compose-deepspeech-csv/config.json
@@ -1,0 +1,4 @@
+{
+  "fileName": 9,
+  "transcript": 10
+}

--- a/compose-deepspeech-csv/index.js
+++ b/compose-deepspeech-csv/index.js
@@ -1,0 +1,108 @@
+'use strict';
+
+const fs = require('fs');
+const readline = require('readline');
+const path = require('path');
+const os = require('os');
+const n2w = require('number-to-words');
+const parse = require('csv-parse/lib/sync');
+const settings = require('./config.json');
+
+console.error(JSON.stringify(settings, null, 2));
+
+// Check argv and print out usage if needed
+function usage(argv) {
+  if (!argv || argv.length !== 5) {
+    console.info('usage: node . <origin csv> <data dir> <output prefix>');
+    return false;
+  }
+
+  if (!fs.existsSync(argv[2])) {
+    console.error(`csv: ${argv[2]} does not exist`);
+    return false;
+  }
+  try {
+    let stat = fs.lstatSync(argv[3]);
+    if (!stat.isDirectory()) {
+      console.error(`data directory: ${argv[3]} is not a directory`);
+      return false;
+    }
+  } catch (e) {
+    console.error(`data directory: ${argv[3]} does not exist`);
+    return false;
+  }
+}
+
+// Parse recording csv and get wav file and transcript and then generate
+// csv file for DeepSpeech for each data directory
+function parseCSV(originCSV, dataDir, output) {
+  const rl = readline.createInterface({
+    input: fs.createReadStream(originCSV),
+    crlfDelay: Infinity
+  });
+
+  let csvData = {};
+  let numRe = /\d+/;
+  rl.on('line', (line) => {
+    try {
+      let columns = parse(line)[0];
+      let transcript = columns[settings.transcript] ?
+        columns[settings.transcript].toLowerCase() : '';
+      transcript = transcript.replace(/[`",?!]/g, '')
+        .replace('-', ' ').replace(/\.$/, '').replace('km', 'kilometer');
+
+      // Number to words
+      let matched = numRe.exec(transcript);
+      if (matched !== null) {
+        transcript = transcript.replace(matched[0], n2w.toWords(matched[0]));
+      }
+
+      csvData[columns[settings.fileName]] = transcript.trim();
+    } catch (e) {
+      console.error(`can not parse this line:${line}`);
+    }
+  });
+
+  rl.on('close', () => {
+    parseDataDir(csvData, dataDir, output);
+  });
+}
+
+// Read wav files from data directory and generate csv for DeepSpeech
+function parseDataDir(csvData, data, output) {
+  if (!path.isAbsolute(data)) {
+    data = path.join(__dirname, data);
+  }
+  let files = fs.readdirSync(data);
+  files.forEach((file) => {
+    // Write a csv file which contains all wav files for this directory
+    let fullPath = path.join(data, file);
+    let stat = fs.lstatSync(fullPath);
+    if (stat.isDirectory()) {
+      // Get all wav files
+      fs.readdir(fullPath, (error, files) => {
+        let outputCSV = output;
+        if (!path.isAbsolute(output)) {
+          outputCSV = path.join(__dirname, output);
+        }
+        outputCSV = path.join(outputCSV, `${file}.csv`);
+        let outputS = fs.createWriteStream(outputCSV);
+        outputS.write(`wav_filename,wav_filesize,transcript\n`);
+        files.forEach( (wav) => {
+          // Write a line for each wav file
+          let wavFull = path.join(fullPath, wav);
+          let fSize = fs.lstatSync(wavFull);
+          outputS.write(`${wavFull},${fSize.size},${csvData[wav]}\n`);
+        });
+        outputS.end();
+      });
+    }
+  });
+}
+
+
+if (usage(process.argv) === false) {
+  process.exit(1);
+}
+
+parseCSV(process.argv[2], process.argv[3], process.argv[4]);

--- a/compose-deepspeech-csv/package.json
+++ b/compose-deepspeech-csv/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "compose-deepspeech-csv",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "csv-parse": "^2.5.0",
+    "number-to-words": "^1.2.3"
+  }
+}


### PR DESCRIPTION
A handy tool to generate CSV for DeepSpeech. It needs an CSV which
contains `fileName` and `transcript` and other columns. Also the wav
data set. Then it will generate the CSV for DeepSpeech.

Signed-off-by: Yihong Wang <yh.wang@ibm.com>